### PR TITLE
Enum processing: API Map stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +297,7 @@ dependencies = [
  "cc",
  "clap",
  "clap-verbosity-flag",
+ "itertools",
  "lazy_static",
  "log",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = "1.0.77"
 clap = { version = "4.4.11", features = ["derive"] }
 clap-verbosity-flag = "2.1.1"
+itertools = "0.12.0"
 lazy_static = "1.4.0"
 log = "0.4.20"
 pretty_env_logger = "0.5.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,11 @@ fn main() -> Result<()> {
     let api_map_file_content = fs::read_to_string(api_map_file_path)?;
     let api_map = api_map::parse(&api_map_file_content)?;
 
-    // debug!("Parsed API map: {:#?}", api_map);
+    debug!("Parsed API map: {:#?}", api_map);
 
-    info!("Generating C++ API...");
-    let cpp_api_map = make_hl_ast(api_map, &config.generation);
-    debug!("C++ API: {cpp_api_map:#?}");
+    // info!("Generating C++ API...");
+    // let cpp_api_map = make_hl_ast(api_map, &config.generation);
+    // debug!("C++ API: {cpp_api_map:#?}");
     // let namespaces_list =
     //     group::group_in_namespaces(&config.generation.namespace_exclude, &functions_orig);
     // debug!("Resulting namespaces: {:#?}", namespaces_list);

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,17 +34,11 @@ fn main() -> Result<()> {
     let api_map_file_content = fs::read_to_string(api_map_file_path)?;
     let api_map = api_map::parse(&api_map_file_content)?;
 
-    debug!("Parsed API map: {:#?}", api_map);
+    debug!("Parsed&processed API map: {:#?}", api_map);
 
-    // info!("Generating C++ API...");
-    // let cpp_api_map = make_hl_ast(api_map, &config.generation);
-    // debug!("C++ API: {cpp_api_map:#?}");
-    // let namespaces_list =
-    //     group::group_in_namespaces(&config.generation.namespace_exclude, &functions_orig);
-    // debug!("Resulting namespaces: {:#?}", namespaces_list);
-
-    // info!("Grouping in classes...");
-    // let _class_list = group::group_in_classes(&config.generation.class_exclude, &functions_orig);
+    info!("Generating HL-AST...");
+    let hl_ast = make_hl_ast(api_map, &config.generation);
+    debug!("HL-AST: {hl_ast:#?}");
 
     // info!("Converting groups into AST...");
 

--- a/src/process/namespace.rs
+++ b/src/process/namespace.rs
@@ -1,8 +1,8 @@
+use super::{Argument, Function, Namespace};
+use crate::conf::{ExcludeInclude, NamespacesConfig};
 use log::{debug, trace};
 use rayon::prelude::*;
 use std::collections::HashSet;
-use crate::conf::{ExcludeInclude, NamespacesConfig};
-use super::{Argument, Function, Namespace};
 
 pub fn namespace_generator(
     functions: &[Function],


### PR DESCRIPTION
Does 3 things:
1. If an enum is wrapped in a typedef, that enum is extracted, and given the name of the typedef.
2. If an enum is not wrapped and doesn't have a name, it stays the same.
3. If an enum has a name, we try to find it in the "flat typedef" list (that is, simple typedefs without inline declarations, like `typedef _lv_result_t lv_result_t`), and if found, the name of the typedef is assigned to the enum.
